### PR TITLE
Use beats tls config

### DIFF
--- a/exporter/logstashexporter/config.go
+++ b/exporter/logstashexporter/config.go
@@ -41,8 +41,8 @@ type Config struct {
 }
 
 type Backoff struct {
-	Init time.Duration
-	Max  time.Duration
+	Init time.Duration `mapstructure:"init"`
+	Max  time.Duration `mapstructure:"max"`
 }
 
 // ProxyConfig holds the configuration information required to proxy

--- a/exporter/logstashexporter/config.go
+++ b/exporter/logstashexporter/config.go
@@ -20,25 +20,24 @@ package logstashexporter
 import (
 	"time"
 
-	"github.com/elastic/elastic-agent-libs/transport"
-	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
+	"github.com/elastic/opentelemetry-collector-components/exporter/logstashexporter/internal/elasticagentlib"
 )
 
 type Config struct {
-	Hosts            []string              `mapstructure:"hosts"`
-	Index            string                `mapstructure:"index"`
-	LoadBalance      bool                  `mapstructure:"loadbalance"`
-	BulkMaxSize      int                   `mapstructure:"bulk_max_size"`
-	SlowStart        bool                  `mapstructure:"slow_start"`
-	Timeout          time.Duration         `mapstructure:"timeout"`
-	TTL              time.Duration         `mapstructure:"ttl"               validate:"min=0"`
-	Pipelining       int                   `mapstructure:"pipelining"        validate:"min=0"`
-	CompressionLevel int                   `mapstructure:"compression_level" validate:"min=0, max=9"`
-	MaxRetries       int                   `mapstructure:"max_retries"       validate:"min=-1"`
-	TLS              *tlscommon.Config     `mapstructure:"ssl"`
-	Proxy            transport.ProxyConfig `mapstructure:"proxy"`
-	Backoff          Backoff               `mapstructure:"backoff"`
-	EscapeHTML       bool                  `mapstructure:"escape_html"`
+	Hosts            []string                `mapstructure:"hosts"`
+	Index            string                  `mapstructure:"index"`
+	LoadBalance      bool                    `mapstructure:"loadbalance"`
+	BulkMaxSize      int                     `mapstructure:"bulk_max_size"`
+	SlowStart        bool                    `mapstructure:"slow_start"`
+	Timeout          time.Duration           `mapstructure:"timeout"`
+	TTL              time.Duration           `mapstructure:"ttl"               validate:"min=0"`
+	Pipelining       int                     `mapstructure:"pipelining"        validate:"min=0"`
+	CompressionLevel int                     `mapstructure:"compression_level" validate:"min=0, max=9"`
+	MaxRetries       int                     `mapstructure:"max_retries"       validate:"min=-1"`
+	TLS              *elasticagentlib.Config `mapstructure:"ssl"`
+	ProxyConfig      `mapstructure:",squash"`
+	Backoff          Backoff `mapstructure:"backoff"`
+	EscapeHTML       bool    `mapstructure:"escape_html"`
 }
 
 type Backoff struct {
@@ -46,7 +45,20 @@ type Backoff struct {
 	Max  time.Duration
 }
 
+// ProxyConfig holds the configuration information required to proxy
+// connections through a SOCKS5 proxy server.
+type ProxyConfig struct {
+	// URL of the SOCKS proxy. Scheme must be socks5. Username and password can be
+	// embedded in the URL.
+	URL string `mapstructure:"proxy_url"`
+
+	// Resolve names locally instead of on the SOCKS server.
+	LocalResolve bool `mapstructure:"proxy_use_local_resolver"`
+}
+
 func defaultConfig() Config {
+	defaultTLSEnabled := false
+
 	return Config{
 		LoadBalance:      false,
 		Pipelining:       2,
@@ -56,6 +68,12 @@ func defaultConfig() Config {
 		Timeout:          30 * time.Second,
 		MaxRetries:       3,
 		TTL:              0 * time.Second,
+		TLS: &elasticagentlib.Config{
+			Enabled:          &defaultTLSEnabled,
+			VerificationMode: "full",
+			Versions:         []string{"TLSv1.1", "TLSv1.2", "TLSv1.3"},
+			Renegotiation:    "never",
+		},
 		Backoff: Backoff{
 			Init: 1 * time.Second,
 			Max:  60 * time.Second,

--- a/exporter/logstashexporter/config.go
+++ b/exporter/logstashexporter/config.go
@@ -18,9 +18,11 @@
 package logstashexporter
 
 import (
+	"errors"
 	"time"
 
 	"github.com/elastic/opentelemetry-collector-components/exporter/logstashexporter/internal/elasticagentlib"
+	"go.opentelemetry.io/collector/component"
 )
 
 type Config struct {
@@ -82,7 +84,12 @@ func defaultConfig() Config {
 	}
 }
 
+var _ component.Config = (*Config)(nil)
+
 func (cfg *Config) Validate() error {
+	if cfg.Hosts == nil || len(cfg.Hosts) == 0 {
+		return errors.New("hosts must be non-empty")
+	}
 	return nil
 }
 

--- a/exporter/logstashexporter/config.go
+++ b/exporter/logstashexporter/config.go
@@ -24,17 +24,17 @@ import (
 )
 
 type Config struct {
-	Hosts            []string                `mapstructure:"hosts"`
-	Index            string                  `mapstructure:"index"`
-	LoadBalance      bool                    `mapstructure:"loadbalance"`
-	BulkMaxSize      int                     `mapstructure:"bulk_max_size"`
-	SlowStart        bool                    `mapstructure:"slow_start"`
-	Timeout          time.Duration           `mapstructure:"timeout"`
-	TTL              time.Duration           `mapstructure:"ttl"               validate:"min=0"`
-	Pipelining       int                     `mapstructure:"pipelining"        validate:"min=0"`
-	CompressionLevel int                     `mapstructure:"compression_level" validate:"min=0, max=9"`
-	MaxRetries       int                     `mapstructure:"max_retries"       validate:"min=-1"`
-	TLS              *elasticagentlib.Config `mapstructure:"ssl"`
+	Hosts            []string                   `mapstructure:"hosts"`
+	Index            string                     `mapstructure:"index"`
+	LoadBalance      bool                       `mapstructure:"loadbalance"`
+	BulkMaxSize      int                        `mapstructure:"bulk_max_size"`
+	SlowStart        bool                       `mapstructure:"slow_start"`
+	Timeout          time.Duration              `mapstructure:"timeout"`
+	TTL              time.Duration              `mapstructure:"ttl"               validate:"min=0"`
+	Pipelining       int                        `mapstructure:"pipelining"        validate:"min=0"`
+	CompressionLevel int                        `mapstructure:"compression_level" validate:"min=0, max=9"`
+	MaxRetries       int                        `mapstructure:"max_retries"       validate:"min=-1"`
+	TLS              *elasticagentlib.TLSConfig `mapstructure:"ssl"`
 	ProxyConfig      `mapstructure:",squash"`
 	Backoff          Backoff `mapstructure:"backoff"`
 	EscapeHTML       bool    `mapstructure:"escape_html"`
@@ -68,7 +68,7 @@ func defaultConfig() Config {
 		Timeout:          30 * time.Second,
 		MaxRetries:       3,
 		TTL:              0 * time.Second,
-		TLS: &elasticagentlib.Config{
+		TLS: &elasticagentlib.TLSConfig{
 			Enabled:          &defaultTLSEnabled,
 			VerificationMode: "full",
 			Versions:         []string{"TLSv1.1", "TLSv1.2", "TLSv1.3"},

--- a/exporter/logstashexporter/internal/elasticagentlib/tls_config.go
+++ b/exporter/logstashexporter/internal/elasticagentlib/tls_config.go
@@ -1,0 +1,50 @@
+package elasticagentlib
+
+import (
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
+)
+
+type Config struct {
+	Enabled              *bool    `mapstructure:"enabled" config:"enabled"`
+	VerificationMode     string   `mapstructure:"verification_mode" config:"verification_mode"` // one of 'none', 'full'
+	Versions             []string `mapstructure:"supported_protocols" config:"supported_protocols"`
+	CipherSuites         []string `mapstructure:"cipher_suites" config:"cipher_suites"`
+	CAs                  []string `mapstructure:"certificate_authorities" config:"certificate_authorities"`
+	CertificateConfig    `mapstructure:",squash" config:",inline"`
+	CurveTypes           []string `mapstructure:"curve_types" config:"curve_types"`
+	Renegotiation        string   `mapstructure:"renegotiation" config:"renegotiation"`
+	CASha256             []string `mapstructure:"ca_sha256" config:"ca_sha256"`
+	CATrustedFingerprint string   `mapstructure:"ca_trusted_fingerprint" config:"ca_trusted_fingerprint"`
+}
+
+type CertificateConfig struct {
+	Certificate    string `mapstructure:"certificate" config:"certificate"`
+	Key            string `mapstructure:"key" config:"key"`
+	Passphrase     string `mapstructure:"key_passphrase" config:"key_passphrase"`
+	PassphrasePath string `mapstructure:"key_passphrase_path" config:"key_passphrase_path"`
+}
+
+func (c *Config) IsEnabled() bool {
+	return c != nil && (c.Enabled == nil || *c.Enabled)
+}
+
+func (c *Config) ToTLSCommonConfig() *tlscommon.Config {
+	if !c.IsEnabled() {
+		return nil
+	}
+
+	cfg, err := config.NewConfigFrom(c)
+	if err != nil {
+		// TODO log error
+		return nil
+	}
+
+	tcConfig := tlscommon.Config{}
+	if err := cfg.Unpack(&tcConfig); err != nil {
+		// TODO log error
+		return nil
+	}
+
+	return &tcConfig
+}

--- a/exporter/logstashexporter/internal/elasticagentlib/tls_config.go
+++ b/exporter/logstashexporter/internal/elasticagentlib/tls_config.go
@@ -25,11 +25,11 @@ type CertificateConfig struct {
 	PassphrasePath string `mapstructure:"key_passphrase_path" config:"key_passphrase_path"`
 }
 
-func (c *Config) IsEnabled() bool {
+func (c *TLSConfig) IsEnabled() bool {
 	return c != nil && (c.Enabled == nil || *c.Enabled)
 }
 
-func (c *Config) ToTLSCommonConfig() *tlscommon.Config {
+func (c *TLSConfig) ToTLSCommonConfig() *tlscommon.Config {
 	if !c.IsEnabled() {
 		return nil
 	}

--- a/exporter/logstashexporter/internal/elasticagentlib/tls_config.go
+++ b/exporter/logstashexporter/internal/elasticagentlib/tls_config.go
@@ -5,7 +5,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 )
 
-type Config struct {
+type TLSConfig struct {
 	Enabled              *bool    `mapstructure:"enabled" config:"enabled"`
 	VerificationMode     string   `mapstructure:"verification_mode" config:"verification_mode"` // one of 'none', 'full'
 	Versions             []string `mapstructure:"supported_protocols" config:"supported_protocols"`

--- a/exporter/logstashexporter/internal/elasticagentlib/tls_config.go
+++ b/exporter/logstashexporter/internal/elasticagentlib/tls_config.go
@@ -29,22 +29,20 @@ func (c *TLSConfig) IsEnabled() bool {
 	return c != nil && (c.Enabled == nil || *c.Enabled)
 }
 
-func (c *TLSConfig) ToTLSCommonConfig() *tlscommon.Config {
+func (c *TLSConfig) ToTLSCommonConfig() (*tlscommon.Config, error) {
 	if !c.IsEnabled() {
-		return nil
+		return nil, nil
 	}
 
 	cfg, err := config.NewConfigFrom(c)
 	if err != nil {
-		// TODO log error
-		return nil
+		return nil, err
 	}
 
 	tcConfig := tlscommon.Config{}
 	if err := cfg.Unpack(&tcConfig); err != nil {
-		// TODO log error
-		return nil
+		return nil, err
 	}
 
-	return &tcConfig
+	return &tcConfig, nil
 }

--- a/exporter/logstashexporter/logstash.go
+++ b/exporter/logstashexporter/logstash.go
@@ -30,16 +30,19 @@ const (
 )
 
 func makeLogstash(beat beat.Info, observer Observer, lsConfig *Config) ([]NetworkClient, error) {
-	tls, err := tlscommon.LoadTLSConfig(lsConfig.TLS)
+	tls, err := tlscommon.LoadTLSConfig(lsConfig.TLS.ToTLSCommonConfig())
 	if err != nil {
 		return nil, err
 	}
 
 	transp := transport.Config{
 		Timeout: lsConfig.Timeout,
-		Proxy:   &lsConfig.Proxy,
-		TLS:     tls,
-		Stats:   observer,
+		Proxy: &transport.ProxyConfig{
+			URL:          lsConfig.URL,
+			LocalResolve: lsConfig.LocalResolve,
+		},
+		TLS:   tls,
+		Stats: observer,
 	}
 
 	clients := make([]NetworkClient, len(lsConfig.Hosts))

--- a/exporter/logstashexporter/logstash.go
+++ b/exporter/logstashexporter/logstash.go
@@ -31,7 +31,13 @@ const (
 )
 
 func makeLogstash(beat beat.Info, observer Observer, lsConfig *Config, log *zap.Logger) ([]NetworkClient, error) {
-	tls, err := tlscommon.LoadTLSConfig(lsConfig.TLS.ToTLSCommonConfig())
+	tlsCommonConfig, err := lsConfig.TLS.ToTLSCommonConfig()
+	if err != nil {
+		log.Error("Error creating TLS config", zap.Error(err))
+		return nil, err
+	}
+
+	tls, err := tlscommon.LoadTLSConfig(tlsCommonConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Tested with

collector config
```yaml
receivers:
  otlp:
    protocols:
      grpc:
        endpoint: 0.0.0.0:4317

exporters:
  debug:
    verbosity: detailed
  logstash:
    hosts: ["localhost:5044"]
    ssl:
      enabled: true
      certificate_authorities: ["/Users/kcheng/docker/cert/ca.crt"]
      certificate: "/Users/kcheng/docker/cert/client.crt"
      key: "/Users/kcheng/docker/cert/client.key"
      supported_protocols: ["TLSv1.1", "TLSv1.2", "TLSv1.3"]

service:
  pipelines:
    logs:
      receivers: [otlp]
      processors: []
      exporters: [debug, logstash]
```

logstash config
```
input {
    beats {
        port => "5044"
        enrich => "none"
        ssl => true
        ssl_certificate_authorities => ["/Users/kcheng/docker/cert/ca.crt"]
        ssl_certificate => "/Users/kcheng/docker/cert/server.crt"
        ssl_key => "/Users/kcheng/docker/cert/server.pkcs8.key"
        ssl_verify_mode => "force_peer"
    }
}
output {
    stdout { 
        codec => rubydebug { metadata => true } 
    }
}
```